### PR TITLE
Update deps

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { default as pTimeout, TimeoutError } from "https://deno.land/x/p_timeout@1.0.1/mod.ts"
+export { default as pTimeout, TimeoutError } from "https://deno.land/x/p_timeout@1.0.2/mod.ts"


### PR DESCRIPTION
- up to p_timeout@1.0.2 which fixes 'missing field `now`' error

```text
> deno run mod.ts
error: missing field `now` at line 21 column 1
at file:///.../deps.ts:1:51
```